### PR TITLE
Reduce memory allocations in add function

### DIFF
--- a/debounce.go
+++ b/debounce.go
@@ -44,6 +44,12 @@ func New(after time.Duration, options ...Option) func(f func()) {
 		callsLimit: -1,
 	}
 
+	// Creating timer and immediatly stop it, so there will be always allocated Timer
+	d.timer = time.AfterFunc(math.MaxInt64, func() {
+		d.f()
+	})
+	d.timer.Stop()
+
 	for _, opt := range options {
 		opt(d)
 	}
@@ -63,6 +69,9 @@ type debouncer struct {
 
 	startWait time.Time
 	waitLimit time.Duration
+
+	// Stores last function to debounce. Will be called after specified duration.
+	f func()
 }
 
 func (d *debouncer) callLimitReached() bool {
@@ -77,21 +86,25 @@ func (d *debouncer) add(f func()) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	if d.timer != nil {
-		d.timer.Stop()
-	} else {
-		d.calls = 0
+	// Refreshing function reference, so d.timer will call right function
+	d.f = f
+
+	// Restarting timer on call
+	d.timer.Reset(d.after)
+
+	// If this is a first call, store startWait time
+	if d.calls == 0 {
 		d.startWait = time.Now()
 	}
 
+	// Counting restarts
 	d.calls += 1
 
 	// If the function has been called more than the limit, or if the wait time
 	// has exceeded the limit, execute the function immediately.
 	if d.callLimitReached() || d.timeLimitReached() {
-		d.timer = nil
-		f()
-	} else { // Otherwise, set a timer to call the function after the specified duration.
-		d.timer = time.AfterFunc(d.after, f)
+		d.timer.Stop()
+		d.calls = 0
+		d.f()
 	}
 }


### PR DESCRIPTION
Before changes:

```
BenchmarkNew-14                          	24119629	        49.83 ns/op	      96 B/op	       2 allocs/op
BenchmarkNewWithOptions-14               	22667223	        50.74 ns/op	      96 B/op	       2 allocs/op
BenchmarkSingleCall-14                   	14447691	        82.68 ns/op	     112 B/op	       1 allocs/op
BenchmarkMultipleCalls-14                	 1438134	       831.5 ns/op	    1120 B/op	      10 allocs/op
BenchmarkCallLimitTrigger-14             	 3151936	       378.4 ns/op	     448 B/op	       4 allocs/op
BenchmarkTimeLimitTrigger-14             	       1	1001091125 ns/op	     320 B/op	       5 allocs/op
BenchmarkConcurrentCalls-14              	 4043491	       286.7 ns/op	     112 B/op	       1 allocs/op
BenchmarkConcurrentCallsWithLimits-14    	 4287588	       277.4 ns/op	     100 B/op	       0 allocs/op
BenchmarkMemoryUsage-14                  	13758811	        85.03 ns/op	       112.0 bytes/op	     112 B/op	       1 allocs/op
BenchmarkTimerCreation-14                	 7016444	       168.7 ns/op	     224 B/op	       2 allocs/op
BenchmarkDifferentFunctions-14           	13926760	        84.33 ns/op	     112 B/op	       1 allocs/op
BenchmarkScaling/goroutines-1-14         	14002006	        84.34 ns/op	     112 B/op	       1 allocs/op
BenchmarkScaling/goroutines-2-14         	 8178116	       149.4 ns/op	     112 B/op	       1 allocs/op
BenchmarkScaling/goroutines-4-14         	 6236526	       191.7 ns/op	     112 B/op	       1 allocs/op
BenchmarkScaling/goroutines-8-14         	 4765552	       248.8 ns/op	     112 B/op	       1 allocs/op
BenchmarkScaling/goroutines-16-14        	 4224655	       284.2 ns/op	     112 B/op	       1 allocs/op
BenchmarkScaling/goroutines-32-14        	 4175211	       284.3 ns/op	     112 B/op	       1 allocs/op
BenchmarkScaling/goroutines-64-14        	 4210880	       283.0 ns/op	     112 B/op	       1 allocs/op
BenchmarkScaling/goroutines-128-14       	 4197930	       283.9 ns/op	     112 B/op	       1 allocs/op
BenchmarkWithVariousDurations/duration-1ns-14         	 7616409	       154.2 ns/op	     112 B/op	       1 allocs/op
BenchmarkWithVariousDurations/duration-1µs-14         	11733488	       100.2 ns/op	     112 B/op	       1 allocs/op
BenchmarkWithVariousDurations/duration-1ms-14         	13360790	        87.90 ns/op	     112 B/op	       1 allocs/op
BenchmarkWithVariousDurations/duration-10ms-14        	13316490	        88.65 ns/op	     112 B/op	       1 allocs/op
BenchmarkWithVariousDurations/duration-100ms-14       	13093246	        87.23 ns/op	     112 B/op	       1 allocs/op
BenchmarkWithVariousDurations/duration-1s-14          	13458345	        87.05 ns/op	     112 B/op	       1 allocs/op
BenchmarkCallLimitVariations/limit-1-14               	34259691	        35.04 ns/op	       0 B/op	       0 allocs/op
BenchmarkCallLimitVariations/limit-2-14               	17813833	        66.00 ns/op	      56 B/op	       0 allocs/op
BenchmarkCallLimitVariations/limit-5-14               	14779742	        80.26 ns/op	      89 B/op	       0 allocs/op
BenchmarkCallLimitVariations/limit-10-14              	13506382	        84.10 ns/op	     100 B/op	       0 allocs/op
BenchmarkCallLimitVariations/limit-50-14              	13595524	        86.66 ns/op	     109 B/op	       0 allocs/op
BenchmarkCallLimitVariations/limit-100-14             	13370752	        87.70 ns/op	     110 B/op	       0 allocs/op
BenchmarkCallLimitVariations/limit-none-14            	13194460	        87.81 ns/op	     112 B/op	       1 allocs/op
BenchmarkReset-14                                     	26094756	        44.57 ns/op	      16 B/op	       1 allocs/op
BenchmarkHighFrequency-14                             	  133112	      8859 ns/op	   11188 B/op	      99 allocs/op
BenchmarkComparison/direct-call-14                    	1000000000	         0.2492 ns/op	       0 B/op	       0 allocs/op
BenchmarkComparison/debounced-call-14                 	13537288	        88.31 ns/op	     112 B/op	       1 allocs/op
```

After changes:

```
goos: darwin
goarch: arm64
pkg: github.com/floatdrop/debounce
cpu: Apple M3 Max
BenchmarkNew-14                          	 7752045	       129.8 ns/op	     224 B/op	       4 allocs/op
BenchmarkNewWithOptions-14               	 8878254	       134.2 ns/op	     224 B/op	       4 allocs/op
BenchmarkSingleCall-14                   	31227060	        38.53 ns/op	       0 B/op	       0 allocs/op
BenchmarkMultipleCalls-14                	 3107125	       387.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkCallLimitTrigger-14             	 5870539	       204.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkTimeLimitTrigger-14             	       1	1001084541 ns/op	     240 B/op	       5 allocs/op
BenchmarkConcurrentCalls-14              	 7773891	       135.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkConcurrentCallsWithLimits-14    	 8599311	       140.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkMemoryUsage-14                  	30859268	        38.58 ns/op	         0.0000073 bytes/op	       0 B/op	       0 allocs/op
BenchmarkTimerCreation-14                	15450220	        77.24 ns/op	       0 B/op	       0 allocs/op
BenchmarkDifferentFunctions-14           	30324344	        38.61 ns/op	       0 B/op	       0 allocs/op
BenchmarkScaling/goroutines-1-14         	30061908	        38.69 ns/op	       0 B/op	       0 allocs/op
BenchmarkScaling/goroutines-2-14         	18184756	        67.31 ns/op	       0 B/op	       0 allocs/op
BenchmarkScaling/goroutines-4-14         	11648346	       102.8 ns/op	       0 B/op	       0 allocs/op
BenchmarkScaling/goroutines-8-14         	 9179750	       128.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkScaling/goroutines-16-14        	 9262603	       128.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkScaling/goroutines-32-14        	 9415459	       120.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkScaling/goroutines-64-14        	 9621667	       119.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkScaling/goroutines-128-14       	 9883518	       124.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkWithVariousDurations/duration-1ns-14         	28622198	        40.46 ns/op	       0 B/op	       0 allocs/op
BenchmarkWithVariousDurations/duration-1µs-14         	27249940	        43.47 ns/op	       0 B/op	       0 allocs/op
BenchmarkWithVariousDurations/duration-1ms-14         	30517622	        38.67 ns/op	       0 B/op	       0 allocs/op
BenchmarkWithVariousDurations/duration-10ms-14        	30927103	        38.42 ns/op	       0 B/op	       0 allocs/op
BenchmarkWithVariousDurations/duration-100ms-14       	30115033	        38.39 ns/op	       0 B/op	       0 allocs/op
BenchmarkWithVariousDurations/duration-1s-14          	31055296	        38.37 ns/op	       0 B/op	       0 allocs/op
BenchmarkCallLimitVariations/limit-1-14               	29730228	        40.43 ns/op	       0 B/op	       0 allocs/op
BenchmarkCallLimitVariations/limit-2-14               	28163889	        41.93 ns/op	       0 B/op	       0 allocs/op
BenchmarkCallLimitVariations/limit-5-14               	29114994	        40.63 ns/op	       0 B/op	       0 allocs/op
BenchmarkCallLimitVariations/limit-10-14              	30094797	        39.51 ns/op	       0 B/op	       0 allocs/op
BenchmarkCallLimitVariations/limit-50-14              	30647067	        38.76 ns/op	       0 B/op	       0 allocs/op
BenchmarkCallLimitVariations/limit-100-14             	30756184	        38.87 ns/op	       0 B/op	       0 allocs/op
BenchmarkCallLimitVariations/limit-none-14            	30849616	        38.63 ns/op	       0 B/op	       0 allocs/op
BenchmarkReset-14                                     	23222378	        50.28 ns/op	      16 B/op	       1 allocs/op
BenchmarkHighFrequency-14                             	  307722	      3889 ns/op	       0 B/op	       0 allocs/op
BenchmarkComparison/direct-call-14                    	1000000000	         0.2495 ns/op	       0 B/op	       0 allocs/op
BenchmarkComparison/debounced-call-14                 	30919965	        38.55 ns/op	       0 B/op	       0 allocs/op
```