### PR TITLE
V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/floatdrop/debounce/actions/workflows/ci.yaml/badge.svg)](https://github.com/floatdrop/debounce/actions/workflows/ci.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/floatdrop/debounce)](https://goreportcard.com/report/github.com/floatdrop/debounce)
 [![Go Coverage](https://github.com/floatdrop/debounce/wiki/coverage.svg)](https://raw.githack.com/wiki/floatdrop/debounce/coverage.html)
-[![Go Reference](https://pkg.go.dev/badge/github.com/floatdrop/debounce.svg)](https://pkg.go.dev/github.com/floatdrop/debounce)
+[![Go Reference](https://pkg.go.dev/badge/github.com/floatdrop/debounce/v2.svg)](https://pkg.go.dev/github.com/floatdrop/debounce/v2)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A simple, thread-safe debounce library for Go that delays function execution until after a specified duration has elapsed since the last invocation. Perfect for rate limiting, reducing redundant operations, and optimizing performance in high-frequency scenarios.
@@ -12,31 +12,51 @@ A simple, thread-safe debounce library for Go that delays function execution unt
 
 - **Zero allocations**: No allocations on sunbsequent debounce calls
 - **Thread-safe**: Safe for concurrent use across multiple goroutines
-- **Configurable delays and limits**: Set custom behaviour with [WithMaxCalls](https://pkg.go.dev/github.com/floatdrop/debounce#WithMaxCalls) and [WithMaxWait](https://pkg.go.dev/github.com/floatdrop/debounce#WithMaxWait) options
+- **Channel support**: Can be used on top of `chan` with [Chan](https://pkg.go.dev/github.com/floatdrop/debounce/v2#Chan) function.
+- **Configurable delays and limits**: Set custom behaviour with [WithDelay](https://pkg.go.dev/github.com/floatdrop/debounce/v2#WithDelay) and [WithLimit](https://pkg.go.dev/github.com/floatdrop/debounce/v2#WithLimit) options
 - **Zero dependencies**: Built using only Go standard library
 
 ## Installation
 
 ```bash
-go get github.com/floatdrop/debounce
+go get github.com/floatdrop/debounce/v2
 ```
 
 ## Usage
 
-https://github.com/floatdrop/debounce/blob/770f96180424dabfea45ca421cce5aa8e57a46f5/example_test.go#L29-L43
+```golang
+import (
+	"fmt"
+	"time"
+
+	"github.com/floatdrop/debounce/v2"
+)
+
+func main() {
+	debouncer := debounce.New(debounce.WithDelay(200 * time.Millisecond))
+	debouncer.Do(func() { fmt.Println("Hello") })
+	debouncer.Do(func() { fmt.Println("World") })
+	time.Sleep(time.Second)
+	// Output: World
+}
+```
 
 ## Benchmarks
 
 ```bash
-go test -bench=BenchmarkSingleCall -benchmem
+go test -bench=. -benchmem
 ```
 
-| Benchmark                        | Iterations | Time per Op  | Bytes per Op | Allocs per Op |
-|----------------------------------|------------|--------------|--------------|---------------|
-| BenchmarkSingleCall-14           | 47227514   | 25.24 ns/op  | 0 B/op       |  0 allocs/op  |
-
-- ~25ns per debounced call
-- Constant memory usage regardless of call frequency
+```
+goos: darwin
+goarch: arm64
+pkg: github.com/floatdrop/debounce/v2
+cpu: Apple M3 Max
+BenchmarkDebounce_Insert-14    	84140161	       13.73 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDebounce_Do-14        	 5129462	       346.7 ns/op	       0 B/op	       0 allocs/op
+PASS
+ok  	github.com/floatdrop/debounce/v2	7.034s
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ goos: darwin
 goarch: arm64
 pkg: github.com/floatdrop/debounce/v2
 cpu: Apple M3 Max
-BenchmarkDebounce_Insert-14    	84140161	       13.73 ns/op	       0 B/op	       0 allocs/op
-BenchmarkDebounce_Do-14        	 5129462	       346.7 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDebounce_Insert-14    	 3318151	       341.9 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDebounce_Do-14        	 4025568	       393.9 ns/op	       0 B/op	       0 allocs/op
 PASS
-ok  	github.com/floatdrop/debounce/v2	7.034s
+ok  	github.com/floatdrop/debounce/v2	8.574s
 ```
 
 ## Contributing

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,1 @@
 module github.com/floatdrop/debounce
-
-go 1.24.4

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/floatdrop/debounce
+
+go 1.24.4

--- a/v2/debounce.go
+++ b/v2/debounce.go
@@ -1,0 +1,96 @@
+package debounce
+
+import (
+	"time"
+)
+
+// Option is a functional option for configuring the debouncer.
+type Option func(*debounceOptions)
+
+type debounceOptions struct {
+	limit int
+	delay time.Duration
+}
+
+// WithLimit sets the maximum number of incoming inputs before
+// passing most recent value downstream.
+func WithLimit(limit int) Option {
+	return func(options *debounceOptions) {
+		options.limit = limit
+	}
+}
+
+// WithDelay sets time.Duration specifying how long to wait after the last input
+// before sending the most recent value downstream.
+func WithDelay(d time.Duration) Option {
+	return func(options *debounceOptions) {
+		options.delay = d
+	}
+}
+
+// Chan wraps incoming channel and returns channel that emits the last value only
+// after no new values are received for the given delay or limit.
+//
+// If no delay provided - zero delay assumed, so function returns in chan as result.
+func Chan[T any](in <-chan T, opts ...Option) <-chan T {
+	var options debounceOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	// If there is no duration - every incoming element must be passed downstream.
+	if options.delay == 0 {
+		return in
+	}
+
+	out := make(chan T, 1)
+	go func() {
+		defer close(out)
+
+		var (
+			timer  *time.Timer = time.NewTimer(options.delay)
+			value  T
+			hasVal bool
+			count  int
+		)
+
+		// Function to return the timer channel or nil if timer is not set
+		// This avoids blocking on the timer channel if no timer is set
+		timerOrNil := func() <-chan time.Time {
+			if timer != nil && hasVal {
+				return timer.C
+			}
+			return nil
+		}
+
+		for {
+			select {
+			case v, ok := <-in:
+				if !ok { // Input channel is closed, wrapping up
+					if hasVal {
+						out <- value
+					}
+					break
+				}
+
+				if options.limit != 0 { // If WithLimit specified as non-zero value start counting and emitting
+					count++
+					if count >= options.limit {
+						out <- v
+						hasVal = false
+						timer.Stop()
+						continue
+					}
+				}
+
+				value = v
+				hasVal = true
+				timer.Reset(options.delay)
+			case <-timerOrNil():
+				out <- value
+				hasVal = false
+			}
+		}
+	}()
+	return out
+}

--- a/v2/debounce.go
+++ b/v2/debounce.go
@@ -70,7 +70,7 @@ func Chan[T any](in <-chan T, opts ...Option) <-chan T {
 					if hasVal {
 						out <- value
 					}
-					break
+					return
 				}
 
 				if options.limit != 0 { // If WithLimit specified as non-zero value start counting and emitting

--- a/v2/debounce_test.go
+++ b/v2/debounce_test.go
@@ -1,0 +1,91 @@
+package debounce_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/floatdrop/debounce/v2"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// helper to collect output with a timeout
+func collect[T any](ch <-chan T, timeout time.Duration) []T {
+	var results []T
+	timer := time.NewTimer(timeout)
+	for {
+		select {
+		case v, ok := <-ch:
+			if !ok {
+				return results
+			}
+			results = append(results, v)
+		case <-timer.C:
+			return results
+		}
+	}
+}
+
+func TestDebounce_LastValueOnly(t *testing.T) {
+	in := make(chan int)
+	out := debounce.Chan(in, debounce.WithDelay(200*time.Millisecond))
+
+	go func() {
+		in <- 1
+		time.Sleep(50 * time.Millisecond)
+		in <- 2
+		time.Sleep(50 * time.Millisecond)
+		in <- 3
+		time.Sleep(50 * time.Millisecond)
+		in <- 4
+		time.Sleep(300 * time.Millisecond) // wait longer than debounce delay
+		close(in)
+	}()
+
+	result := collect(out, 1*time.Second)
+	assert.Equal(t, []int{4}, result)
+}
+
+func TestDebounce_MultipleValuesSpacedOut(t *testing.T) {
+	in := make(chan int)
+	out := debounce.Chan(in, debounce.WithDelay(100*time.Millisecond))
+
+	go func() {
+		in <- 1
+		time.Sleep(150 * time.Millisecond)
+		in <- 2
+		time.Sleep(150 * time.Millisecond)
+		in <- 3
+		time.Sleep(150 * time.Millisecond)
+		close(in)
+	}()
+
+	result := collect(out, 1*time.Second)
+	assert.Equal(t, []int{1, 2, 3}, result)
+}
+
+func TestDebounce_ChannelCloses(t *testing.T) {
+	in := make(chan int)
+	out := debounce.Chan(in, debounce.WithDelay(100*time.Millisecond))
+
+	go func() {
+		in <- 42
+		time.Sleep(200 * time.Millisecond)
+		close(in)
+	}()
+
+	result := collect(out, 1*time.Second)
+	assert.Equal(t, []int{42}, result)
+}
+
+func BenchmarkDebounce_Insert(b *testing.B) {
+	in := make(chan int, b.N) // This is hacky, because we buffer all incoming data
+	_ = debounce.Chan(in, debounce.WithDelay(100*time.Millisecond))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		in <- i
+	}
+	b.StopTimer()
+	close(in)
+}

--- a/v2/debounce_test.go
+++ b/v2/debounce_test.go
@@ -79,7 +79,7 @@ func TestDebounce_ChannelCloses(t *testing.T) {
 }
 
 func BenchmarkDebounce_Insert(b *testing.B) {
-	in := make(chan int, b.N) // This is hacky, because we buffer all incoming data
+	in := make(chan int)
 	_ = debounce.Chan(in, debounce.WithDelay(100*time.Millisecond))
 
 	b.ResetTimer()

--- a/v2/debounce_test.go
+++ b/v2/debounce_test.go
@@ -64,18 +64,55 @@ func TestDebounce_MultipleValuesSpacedOut(t *testing.T) {
 	assert.Equal(t, []int{1, 2, 3}, result)
 }
 
+func TestDebounce_WithLimit(t *testing.T) {
+	in := make(chan int)
+	out := debounce.Chan(in, debounce.WithDelay(200*time.Millisecond), debounce.WithLimit(3))
+
+	go func() {
+		in <- 1
+		time.Sleep(50 * time.Millisecond)
+		in <- 2
+		time.Sleep(50 * time.Millisecond)
+		in <- 3
+		time.Sleep(50 * time.Millisecond)
+		in <- 4
+		time.Sleep(300 * time.Millisecond) // wait longer than debounce delay
+		close(in)
+	}()
+
+	result := collect(out, 1*time.Second)
+	assert.Equal(t, []int{3, 4}, result)
+}
+
 func TestDebounce_ChannelCloses(t *testing.T) {
 	in := make(chan int)
 	out := debounce.Chan(in, debounce.WithDelay(100*time.Millisecond))
 
 	go func() {
 		in <- 42
-		time.Sleep(200 * time.Millisecond)
 		close(in)
 	}()
 
 	result := collect(out, 1*time.Second)
 	assert.Equal(t, []int{42}, result)
+}
+
+func TestDebounce_EmptyChannelCloses(t *testing.T) {
+	in := make(chan int)
+	out := debounce.Chan(in, debounce.WithDelay(100*time.Millisecond))
+
+	go func() {
+		close(in)
+	}()
+
+	result := collect(out, 1*time.Second)
+	assert.Equal(t, []int(nil), result)
+}
+
+func TestDebounce_ZeroDelay(t *testing.T) {
+	in := make(chan int)
+	out := debounce.Chan(in)
+	assert.Equal(t, (<-chan int)(in), out)
 }
 
 func BenchmarkDebounce_Insert(b *testing.B) {

--- a/v2/debouncer.go
+++ b/v2/debouncer.go
@@ -7,12 +7,12 @@ type Debouncer struct {
 
 // Creates new Debouncer instance that will call provided functions with debounce.
 func New(opts ...Option) *Debouncer {
-	inputCh := make(chan func(), 1)
+	inputCh := make(chan func())
 	debouncedCh := Chan(inputCh, opts...)
 
 	go func() {
 		for f := range debouncedCh {
-			f()
+			go f() // Do not block reading channel for f execution
 		}
 	}()
 

--- a/v2/debouncer.go
+++ b/v2/debouncer.go
@@ -1,0 +1,40 @@
+package debounce
+
+type Debouncer struct {
+	inputCh     chan func()
+	debouncedCh <-chan func()
+}
+
+// Creates new Debouncer instance that will call provided functions with debounce.
+func New(opts ...Option) *Debouncer {
+	inputCh := make(chan func(), 1)
+	debouncedCh := Chan(inputCh, opts...)
+
+	go func() {
+		for f := range debouncedCh {
+			f()
+		}
+	}()
+
+	return &Debouncer{
+		inputCh:     inputCh,
+		debouncedCh: debouncedCh,
+	}
+}
+
+// Do adds function f to be executed with debounce.
+func (d *Debouncer) Do(f func()) {
+	d.inputCh <- f
+}
+
+// Func returns func wrapper of function f, that will execute function f with debounce on call.
+func (d *Debouncer) Func(f func()) func() {
+	return func() {
+		d.inputCh <- f
+	}
+}
+
+// Closes underlying channel in Debouncer instance.
+func (d *Debouncer) Close() {
+	close(d.inputCh)
+}

--- a/v2/debouncer_test.go
+++ b/v2/debouncer_test.go
@@ -1,0 +1,19 @@
+package debounce_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/floatdrop/debounce/v2"
+)
+
+func BenchmarkDebounce_Do(b *testing.B) {
+	debouncer := debounce.New(debounce.WithDelay(100 * time.Millisecond))
+	f := func() {}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		debouncer.Do(f)
+	}
+	b.StopTimer()
+	debouncer.Close()
+}

--- a/v2/example_test.go
+++ b/v2/example_test.go
@@ -1,0 +1,42 @@
+package debounce_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/floatdrop/debounce/v2"
+)
+
+func ExampleNew() {
+	debouncer := debounce.New(debounce.WithDelay(200 * time.Millisecond))
+	debouncer.Do(func() { fmt.Println("Hello") })
+	debouncer.Do(func() { fmt.Println("World") })
+	time.Sleep(time.Second)
+	// Output: World
+}
+
+func ExampleChan() {
+	in := make(chan int)
+	out := debounce.Chan(in, debounce.WithDelay(200*time.Millisecond))
+
+	go func() {
+		for value := range out {
+			fmt.Println(value)
+		}
+	}()
+
+	go func() {
+		in <- 1
+		time.Sleep(50 * time.Millisecond)
+		in <- 2
+		time.Sleep(50 * time.Millisecond)
+		in <- 3
+		time.Sleep(50 * time.Millisecond)
+		in <- 4
+		time.Sleep(300 * time.Millisecond) // wait longer than debounce delay
+		close(in)
+	}()
+
+	time.Sleep(time.Second)
+	// Output: 4
+}

--- a/v2/example_test.go
+++ b/v2/example_test.go
@@ -2,6 +2,7 @@ package debounce_test
 
 import (
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/floatdrop/debounce/v2"
@@ -12,7 +13,20 @@ func ExampleNew() {
 	debouncer.Do(func() { fmt.Println("Hello") })
 	debouncer.Do(func() { fmt.Println("World") })
 	time.Sleep(time.Second)
+	debouncer.Close()
 	// Output: World
+}
+
+func ExampleDebouncer_Func() {
+	var counter int32
+	debouncer := debounce.New(debounce.WithDelay(200 * time.Millisecond)).Func(func() {
+		atomic.AddInt32(&counter, 1)
+	})
+	debouncer()
+	debouncer()
+	time.Sleep(time.Second)
+	fmt.Println(counter)
+	// Output: 1
 }
 
 func ExampleChan() {

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,0 +1,11 @@
+module github.com/floatdrop/debounce/v2
+
+go 1.23
+
+require github.com/stretchr/testify v1.10.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This version introduce Chan constructor, that will return debounced channel. On top of this
function we can now construct `Debouncer` with `Close` method, that perfectly aligns with go core concepts.

- WithMaxWait is removed to reduce confusion, when configuring debounce. WithLimit will suffice for first release. Closes #10 
- `Close` method added on `Debouncer`. Closes #7

Some performance degradation is expected.